### PR TITLE
Add a flag for turning off the recursive lookup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "sp-niemand/yii2-migrate",
-    "description": "Extended migration support (forked from https://github.com/fishvision/yii2-migrate)",
+    "name": "fishvision/yii2-migrate",
+    "description": "Extended migration support",
     "type": "yii2-extension",
     "keywords": ["yii2","extension"],
     "license": "MIT",

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "fishvision/yii2-migrate",
-    "description": "Extended migration support",
+    "name": "sp-niemand/yii2-migrate",
+    "description": "Extended migration support (forked from https://github.com/fishvision/yii2-migrate)",
     "type": "yii2-extension",
     "keywords": ["yii2","extension"],
     "license": "MIT",


### PR DESCRIPTION
And make migrations searchable in sub-directories different from `migrations`.
